### PR TITLE
feat: dynamic color palettes(WIP)

### DIFF
--- a/graphql/GetColorPalettes.graphql
+++ b/graphql/GetColorPalettes.graphql
@@ -6,5 +6,6 @@ query GetColorPaletts {
                 color
             }
         }
+        totalCount
     }
 }

--- a/graphql/GetColorPalettes.graphql
+++ b/graphql/GetColorPalettes.graphql
@@ -1,0 +1,10 @@
+query GetColorPaletts {
+    paletteColorsModels{
+        edges{
+            node{
+                idx,
+                color
+            }
+        }
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,7 +162,7 @@ function App() {
             <div className={styles.main}>
 
                 <Routes>
-                    <Route path="/settings" element={<Settings/>}/>
+                    {/* <Route path="/settings" element={<Settings/>}/> */}
                     <Route path="/" element={
                         <>
                             <Viewport
@@ -201,7 +201,7 @@ function App() {
                     }/>
                     <Route path="/governance" element={<Governance />} />
                     <Route path="/new-proposal" element={<NewProposal />} />
-                    <Route path="/proposal/:id" element={<ProposalDetails />} />
+                    {/* <Route path="/proposal/:id" element={<ProposalDetails />} /> */}
 
                 </Routes>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import React, {useEffect, useMemo, useState, useRef} from "react";
 import {Bounds, Coordinate} from "@/webtools/types.ts";
 import {useSimpleTileStore} from "@/webtools/hooks/SimpleTileStore.ts";
 import {useDojoPixelStore} from "@/stores/DojoPixelStore.ts";
+import {useDojoColorPalettesStore} from "@/stores/DojoColorPalettesStore.ts";
 import {useUpdateService} from "@/webtools/hooks/UpdateService.ts";
 import Viewport from "@/webtools/components/Viewport/ViewPort.tsx";
 import SimpleColorPicker from "@/components/ColorPicker/SimpleColorPicker.tsx";
@@ -36,6 +37,7 @@ function App() {
 
     const updateService = useUpdateService(settings.config?.serverUrl!)
     const pixelStore = useDojoPixelStore(settings.config?.toriiUrl!);
+    const colorPalettesStore = useDojoColorPalettesStore(settings.config?.toriiUrl!);
     const tileStore = useSimpleTileStore(`${settings.config?.serverUrl}/tiles`)
     const appStore = useDojoAppStore();
     const {clientState, error, gameData} = usePixelawProvider();
@@ -187,6 +189,10 @@ function App() {
                             <div className={styles.buttonContainer}>
                                 <button className={styles.placePixelButton} onClick={() => {toggleColorPicker(); setSelectedApp('p_war');}} style={{ display: isColorPickerVisible ? 'none' : 'flex' }}>
                                     Place a Pixel
+                                </button>
+
+                                <button onClick={colorPalettesStore.getColorPalette}>
+                                    Update a color palette.
                                 </button>
                             </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useMemo, useState, useRef} from "react";
 import {Bounds, Coordinate} from "@/webtools/types.ts";
 import {useSimpleTileStore} from "@/webtools/hooks/SimpleTileStore.ts";
 import {useDojoPixelStore} from "@/stores/DojoPixelStore.ts";
-import {useDojoColorPalettesStore} from "@/stores/DojoColorPalettesStore.ts";
+// import {useDojoColorPalettesStore} from "@/stores/DojoColorPalettesStore.ts";
 import {useUpdateService} from "@/webtools/hooks/UpdateService.ts";
 import Viewport from "@/webtools/components/Viewport/ViewPort.tsx";
 import SimpleColorPicker from "@/components/ColorPicker/SimpleColorPicker.tsx";
@@ -37,7 +37,7 @@ function App() {
 
     const updateService = useUpdateService(settings.config?.serverUrl!)
     const pixelStore = useDojoPixelStore(settings.config?.toriiUrl!);
-    const colorPalettesStore = useDojoColorPalettesStore(settings.config?.toriiUrl!);
+    // const colorPalettesStore = useDojoColorPalettesStore(settings.config?.toriiUrl!);
     const tileStore = useSimpleTileStore(`${settings.config?.serverUrl}/tiles`)
     const appStore = useDojoAppStore();
     const {clientState, error, gameData} = usePixelawProvider();
@@ -180,7 +180,12 @@ function App() {
                             />
                             {/* <div className={styles.colorpicker} style={{bottom: zoombasedAdjustment}}> */}
                             <div className={styles.colorpicker} style={{ bottom: zoombasedAdjustment, display: isColorPickerVisible ? 'flex' : 'none' }}>
-                                <SimpleColorPicker color={color} onColorSelect={onColorSelect}/>
+                                <SimpleColorPicker
+                                    color={color}
+                                    onColorSelect={onColorSelect}
+                                    // toriiUrl={settings.config?.toriiUrl!}
+                                    // colorPalettesStore={colorPalettesStore}
+                                />
                                 <button className={styles.closeButton} onClick={toggleColorPicker}>
                                     <RiArrowGoBackFill size={22}/>
                                 </button>
@@ -191,9 +196,9 @@ function App() {
                                     Place a Pixel
                                 </button>
 
-                                <button onClick={colorPalettesStore.getColorPalette}>
+                                {/* <button onClick={colorPalettesStore.getColorPalette}>
                                     Update a color palette.
-                                </button>
+                                </button> */}
                             </div>
 
 

--- a/src/components/ColorPicker/SimpleColorPicker.tsx
+++ b/src/components/ColorPicker/SimpleColorPicker.tsx
@@ -1,4 +1,17 @@
 import styles from './SimpleColorPicker.module.css';
+import GET_COLOR_PALETTS_QUERY from "@/../graphql/GetColorPalettes.graphql";
+import { GraphQLClient } from 'graphql-request';
+import { ColorPalette } from "@/webtools/types.ts";
+
+
+type GetColorPalettesResponse = {
+  paletteColorsModels: {
+      edges: Array<{
+          node: ColorPalette;
+      }>;
+  };
+};
+
 
 const colors = [
     "#FF0000",

--- a/src/components/ColorPicker/SimpleColorPicker.tsx
+++ b/src/components/ColorPicker/SimpleColorPicker.tsx
@@ -1,17 +1,19 @@
+import React, { useEffect, useState } from 'react';
 import styles from './SimpleColorPicker.module.css';
 import GET_COLOR_PALETTS_QUERY from "@/../graphql/GetColorPalettes.graphql";
 import { GraphQLClient } from 'graphql-request';
 import { ColorPalette } from "@/webtools/types.ts";
+import {useDojoColorPalettesStore} from "@/stores/DojoColorPalettesStore.ts";
+import { numRGBToHex } from '@/webtools/utils';
 
 
-type GetColorPalettesResponse = {
-  paletteColorsModels: {
-      edges: Array<{
-          node: ColorPalette;
-      }>;
-  };
-};
-
+// type GetColorPalettesResponse = {
+//   paletteColorsModels: {
+//       edges: Array<{
+//           node: ColorPalette;
+//       }>;
+//   };
+// };
 
 const colors = [
     "#FF0000",
@@ -26,12 +28,42 @@ const colors = [
 ];
 
 export interface ColorPickerProps {
-    onColorSelect: (color: string) => void;
     color: string;
+    onColorSelect: (color: string) => void;
+    // toriiUrl: string | undefined;
 }
 
 const SimpleColorPicker: React.FC<ColorPickerProps> = ({onColorSelect, color: selectedColor}) => {
-    selectedColor = `#${selectedColor}`
+  // const [colors, setColors] = useState<string[]>([]);
+  // const [error, setError] = useState<string | null>(null);
+  // const { refresh, getColorPalette } = useDojoColorPalettesStore(toriiUrl!);
+  // console.log("colorPalettesStore", colorPalettesStore);
+  // console.log(colorPalettesStore.getColorPalette());
+
+  // useEffect(() => {
+  //   const fetchData = async () => {
+  //     try {
+  //       await refresh();
+  //       const state = getColorPalette();
+  //       if (Object.keys(state).length === 0) {
+  //         setError('No color palettes found (for the provided game_id).');
+  //       } else {
+  //         const hexColors = Object.values(state)
+  //           .filter((value): value is number => value !== undefined)
+  //           .map(numRGBToHex);
+  //         setColors(hexColors);
+  //         setError(null);
+  //       }
+  //     } catch (e) {
+  //       setError(`An error occurred while fetching color palettes: ${e.message}`);
+  //       console.error(e);
+  //     }
+  //   };
+
+  //   fetchData();
+  // }, []);
+
+  selectedColor = `#${selectedColor}`
 
     return (
         <div className={styles.inner}>

--- a/src/components/MenuBar/MenuBar.tsx
+++ b/src/components/MenuBar/MenuBar.tsx
@@ -22,12 +22,11 @@ const MenuBar: React.FC = () => {
         <div className={styles.inner}>
             <div className={styles.logoContainer} onClick={() => navigate('/')}>
                 <img src="/assets/logo/pixeLaw-logo.png" alt="logo"/>
-
             </div>
             <div>
                 {showGovernance && <button className={styles.menuButton} onClick={() => navigate('/governance')}>Governance</button>}
-                {!showGovernance && <button className={styles.menuButton} onClick={() => navigate('/')}>Draw</button>}
-                <button className={styles.menuButton} onClick={toggleSettings}>Settings</button>
+                {/* {!showGovernance && <button className={styles.menuButton} onClick={() => navigate('/')}>Draw</button>} */}
+                {/* <button className={styles.menuButton} onClick={toggleSettings}>Settings</button> */}
             </div>
         </div>
     );

--- a/src/stores/DojoColorPalettesStore.ts
+++ b/src/stores/DojoColorPalettesStore.ts
@@ -16,13 +16,11 @@ type GetColorPalettesResponse = {
         }>;
     };
   };
-
+  
 interface ColorPaletteStore {
     refresh: () => void;
     getColorPalette: () => State | undefined;
 }
-
-  
 
 // idx -> color
 type State = { [key: number]: number | undefined };

--- a/src/stores/DojoColorPalettesStore.ts
+++ b/src/stores/DojoColorPalettesStore.ts
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { ColorPalette } from "@/webtools/types.ts";
+import { produce } from 'immer';
+import GET_COLOR_PALETTS_QUERY from "@/../graphql/GetColorPalettes.graphql";
+import { GraphQLClient } from 'graphql-request';
+import { areBoundsEqual, MAX_VIEW_SIZE } from "@/webtools/utils.ts";
+import { shortString } from "starknet";
+import { get } from 'idb-keyval';
+
+// TODO local declaration to deal with typing. Should come from World__Query but thats very generic
+
+type GetColorPalettesResponse = {
+    paletteColorsModels: {
+        edges: Array<{
+            node: ColorPalette;
+        }>;
+    };
+  };
+
+interface ColorPaletteStore {
+    refresh: () => void;
+    getColorPalette: () => State | undefined;
+}
+
+  
+
+// idx -> color
+type State = { [key: number]: number | undefined };
+// type State = { [key: string]: Pixel | undefined };
+
+// FIXME: should combine this to game_id.
+export function useDojoColorPalettesStore(baseUrl?: string) : ColorPaletteStore {
+    const [state, setState] = useState<State>({});
+    // const [bounds, setBounds] = useState<Bounds>([[0, 0], [MAX_VIEW_SIZE, MAX_VIEW_SIZE]]);
+    // const [cacheUpdated, setCacheUpdated] = useState<number>(Date.now());
+
+    const gqlClient = baseUrl ? new GraphQLClient(`${baseUrl}/graphql`) : null;
+
+    function fetchData(): void {
+        if (!gqlClient) return;
+
+        // let [[left, top], [right, bottom]] = bounds;
+
+        // if (left > MAX_VIEW_SIZE && left > right) right = MAX_UINT32;
+        // if (top > MAX_VIEW_SIZE && top > bottom) bottom = MAX_UINT32;
+
+        gqlClient.request<GetColorPalettesResponse>(GET_COLOR_PALETTS_QUERY, {
+            // first: 8
+        }).then((data) => {
+            const newState: State = {};
+            data.paletteColorsModels.edges.forEach(({ node }: { node: ColorPalette }) => {
+              newState[node.idx] = node.color;
+            });
+            setState(produce((draftState) => {
+              Object.assign(draftState, newState);
+            }));
+            
+            // data!.paletteColorsModels!.edges!.map(({ node }: { node: ColorPalette }) => {
+            //     const ColorPalette: ColorPalette = {
+            //         ...node,
+            //         // color: parseInt(node.color as string, 16),
+            //         color: node.color,
+            //         idx: node.idx
+            //     };
+            //     setState(produce(draftState => {
+            //         draftState[node.idx] = node.color;
+            //     }));
+            // });
+            
+            
+            // data!.pixelModels!.edges!.map(({ node }: { node: Pixel }) => {
+            //     const pixel: Pixel = {
+            //         ...node,
+            //         text: shortString.decodeShortString(node.text),
+            //         action: shortString.decodeShortString(node.action),
+            //         timestamp: parseInt(node.timestamp as string, 16),
+            //     }
+
+            //     setState(produce(draftState => {
+            //         draftState[`${node.x}_${node.y}`] = pixel;
+            //     }));
+            // })
+
+            // setCacheUpdated(Date.now())
+
+        }).catch((e) => {
+            console.error("Error retrieving Color Palettes from torii for", e.message)
+        })
+    }
+
+    const refresh = (): void => {
+        console.log("ColorPalettes.refresh");
+        fetchData();
+    }
+
+    const getColorPalette = (): State => {
+        console.log("ColorPalettes.get");
+        fetchData();
+        console.log(state);
+        return state;
+    };
+
+    // const prepare = (newBounds: Bounds): void => {
+    //     if (!areBoundsEqual(bounds, newBounds)) {
+    //         setBounds(newBounds);
+    //         refresh();
+    //     }
+    // };
+
+    // const getPixel = (coord: Coordinate): Pixel | undefined => {
+    //     const key = `${coord[0]}_${coord[1]}`;
+
+    //     return state[key];
+    // };
+
+    // const setPixel = (key: string, pixel: Pixel): void => {
+    //     setState(produce(draft => {
+    //         draft[key] = pixel;
+    //     }));
+    // };
+
+    // const setPixels = (pixels: { key: string, pixel: Pixel }[]): void => {
+    //     setState(produce(draft => {
+    //         pixels.forEach(({ key, pixel }) => {
+    //             draft[key] = pixel;
+    //         });
+    //     }));
+    return { refresh, getColorPalette };
+
+};

--- a/src/webtools/components/Viewport/drawPixels.ts
+++ b/src/webtools/components/Viewport/drawPixels.ts
@@ -49,7 +49,7 @@ export function drawPixels(
 
 
     if (hoveredCell && zoom > ZOOM_TILEMODE) {
-        drawPixel(hoveredCell[0], hoveredCell[1], 15);
+        drawPixel(hoveredCell[0], hoveredCell[1], 2);
     }
 }
 

--- a/src/webtools/types.ts
+++ b/src/webtools/types.ts
@@ -13,6 +13,14 @@ export type ColorPalette = {
     color: number
 }
 
+// type PaletteState = { [key: number]: number | undefined };
+
+// export interface ColorPaletteStore {
+//     refresh: () => void;
+//     getColorPalette: () => PaletteState | undefined;
+// }
+
+
 export type App = {
     "system": string,
     "name": string,

--- a/src/webtools/types.ts
+++ b/src/webtools/types.ts
@@ -8,6 +8,11 @@ export type Pixel = {
     y: number
 }
 
+export type ColorPalette = {
+    idx: number
+    color: number
+}
+
 export type App = {
     "system": string,
     "name": string,


### PR DESCRIPTION
I've created followings to treat color palettes dinamically, but it's still buggy.
- useDojoColorPalettesStore
- update SimpleColorPicker
- GetColorPalettes

The error is:
`no rows returned by a query that expected to return at least one row", details: [], metadata: MetadataMap { headers: {"content-length": "0", "content-type": "application/grpc-web+proto"} }`

Before merge it, we have to fix it.